### PR TITLE
Build multi-page experience with configurable screening workflow

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,1143 @@
+:root {
+    --primary: #5b5bcf;
+    --primary-dark: #32328c;
+    --accent: #ff9d4d;
+    --bg: #f5f5fb;
+    --text: #1f1f3d;
+    --muted: #6b6b8f;
+    --card-bg: #ffffff;
+    --shadow: 0 24px 60px rgba(50, 50, 140, 0.12);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+    color: var(--text);
+    background: var(--bg);
+}
+
+header {
+    background: radial-gradient(circle at 10% 20%, rgba(91, 91, 207, 0.2), transparent 60%),
+        radial-gradient(circle at 90% 10%, rgba(255, 157, 77, 0.3), transparent 55%),
+        linear-gradient(135deg, #ffffff 0%, #f5f5fb 50%, #e6e6f9 100%);
+    padding: 24px 0 80px;
+}
+
+.container {
+    width: min(1120px, 92vw);
+    margin: 0 auto;
+}
+
+nav {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 48px;
+}
+
+nav .logo {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    text-decoration: none;
+    color: var(--primary-dark);
+    font-weight: 700;
+    font-size: 1.25rem;
+}
+
+nav .logo span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+    background: var(--primary);
+    color: white;
+    font-size: 1.2rem;
+    box-shadow: var(--shadow);
+}
+
+nav ul {
+    list-style: none;
+    display: flex;
+    gap: 24px;
+    margin: 0;
+    padding: 0;
+}
+
+nav a {
+    text-decoration: none;
+    color: var(--muted);
+    font-weight: 600;
+    font-size: 0.95rem;
+    transition: color 0.3s ease;
+}
+
+nav a:hover,
+nav a:focus {
+    color: var(--primary-dark);
+}
+
+.button {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 20px;
+    border-radius: 999px;
+    font-weight: 600;
+    background: var(--primary);
+    color: white;
+    text-decoration: none;
+    box-shadow: var(--shadow);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button:hover,
+.button:focus {
+    transform: translateY(-2px);
+    box-shadow: 0 16px 40px rgba(91, 91, 207, 0.25);
+}
+
+.hero {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 40px;
+    align-items: center;
+}
+
+.hero h1 {
+    font-size: clamp(2.2rem, 5vw, 3.2rem);
+    margin: 0 0 16px;
+    letter-spacing: -0.03em;
+}
+
+.hero p {
+    font-size: 1.05rem;
+    line-height: 1.6;
+    color: var(--muted);
+    margin-bottom: 28px;
+}
+
+.hero-card {
+    background: var(--card-bg);
+    border-radius: 24px;
+    padding: 24px;
+    box-shadow: var(--shadow);
+    position: relative;
+    overflow: hidden;
+}
+
+.hero-card::before {
+    content: "Matcha";
+    position: absolute;
+    top: -40px;
+    right: -40px;
+    width: 160px;
+    height: 160px;
+    background: rgba(91, 91, 207, 0.1);
+    border-radius: 50%;
+}
+
+.profile-card {
+    background: linear-gradient(145deg, #ffffff 0%, #f3f3ff 100%);
+    border-radius: 20px;
+    padding: 20px;
+    display: grid;
+    gap: 16px;
+}
+
+.profile-header {
+    display: flex;
+    gap: 16px;
+    align-items: center;
+}
+
+.profile-avatar {
+    width: 64px;
+    height: 64px;
+    border-radius: 18px;
+    background: #e6e6f9;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 2rem;
+}
+
+.tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: rgba(91, 91, 207, 0.12);
+    color: var(--primary-dark);
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.swipe-actions {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.swipe-button {
+    flex: 1;
+    border: none;
+    border-radius: 999px;
+    padding: 12px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.swipe-button.no {
+    background: #ffe2e2;
+    color: #c93c3c;
+}
+
+.swipe-button.yes {
+    background: var(--primary);
+    color: white;
+}
+
+.swipe-button:hover,
+.swipe-button:focus {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow);
+}
+
+section {
+    padding: 80px 0;
+}
+
+.section-header {
+    text-align: center;
+    max-width: 680px;
+    margin: 0 auto 48px;
+}
+
+.section-header h2 {
+    font-size: clamp(2rem, 4vw, 2.6rem);
+    margin-bottom: 16px;
+}
+
+.section-header p {
+    color: var(--muted);
+    line-height: 1.6;
+}
+
+.feature-grid {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.feature-card {
+    background: var(--card-bg);
+    border-radius: 20px;
+    padding: 28px;
+    box-shadow: var(--shadow);
+    display: grid;
+    gap: 16px;
+}
+
+.feature-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 14px;
+    background: rgba(91, 91, 207, 0.12);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+    color: var(--primary-dark);
+}
+
+.feature-card p {
+    color: var(--muted);
+    line-height: 1.6;
+    margin: 0;
+}
+
+.intake-grid {
+    display: grid;
+    gap: 32px;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    align-items: start;
+}
+
+.intake-card {
+    background: var(--card-bg);
+    border-radius: 24px;
+    padding: 32px;
+    box-shadow: var(--shadow);
+    display: grid;
+    gap: 24px;
+}
+
+.intake-card h3 {
+    margin: 0;
+}
+
+.intake-card p {
+    color: var(--muted);
+    line-height: 1.6;
+    margin: 0;
+}
+
+.intake-card ul {
+    margin: 0;
+    padding-left: 20px;
+    color: var(--muted);
+    display: grid;
+    gap: 8px;
+    line-height: 1.6;
+}
+
+.intake-form {
+    display: grid;
+    gap: 24px;
+}
+
+.form-group {
+    display: grid;
+    gap: 8px;
+}
+
+.form-group label {
+    font-weight: 600;
+}
+
+.form-group input[type="text"],
+.form-group input[type="email"],
+.form-group input[type="number"],
+.form-group select,
+.form-group textarea {
+    border: 1px solid #d8d8ef;
+    border-radius: 12px;
+    padding: 12px 14px;
+    font-size: 1rem;
+    font-family: inherit;
+    background: #f9f9ff;
+}
+
+.form-group input[type="text"]:focus,
+.form-group input[type="email"]:focus,
+.form-group input[type="number"]:focus,
+.form-group select:focus,
+.form-group textarea:focus {
+    outline: 2px solid rgba(91, 91, 207, 0.35);
+    outline-offset: 2px;
+}
+
+fieldset {
+    border: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 16px;
+}
+
+fieldset legend {
+    font-weight: 700;
+    color: var(--text);
+}
+
+.radio-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.radio-pill {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid #d8d8ef;
+    border-radius: 999px;
+    padding: 2px;
+    background: #ffffff;
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.radio-pill input {
+    position: absolute;
+    opacity: 0;
+}
+
+.radio-pill span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 48px;
+    padding: 8px 16px;
+    border-radius: 999px;
+    font-weight: 600;
+    color: var(--muted);
+    transition: inherit;
+}
+
+.radio-pill input:focus-visible + span {
+    outline: 2px solid rgba(91, 91, 207, 0.35);
+    outline-offset: 2px;
+    border-radius: 999px;
+}
+
+.radio-pill input:checked + span {
+    background: var(--primary);
+    color: white;
+}
+
+.intake-actions {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.form-feedback {
+    font-weight: 600;
+}
+
+.form-feedback.success {
+    color: #1a8654;
+}
+
+.form-feedback.error {
+    color: #c93c3c;
+}
+
+.candidate-database {
+    background: linear-gradient(145deg, #ffffff 0%, #f3f3ff 100%);
+    border-radius: 24px;
+    padding: 32px;
+    box-shadow: var(--shadow);
+    display: grid;
+    gap: 24px;
+}
+
+.candidate-database header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+}
+
+.candidate-database header h3 {
+    margin: 0;
+}
+
+.candidate-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(91, 91, 207, 0.12);
+    color: var(--primary-dark);
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-weight: 600;
+}
+
+.candidate-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 16px;
+}
+
+.candidate-card {
+    background: white;
+    border-radius: 18px;
+    padding: 20px;
+    display: grid;
+    gap: 12px;
+    border: 1px solid rgba(91, 91, 207, 0.1);
+}
+
+.candidate-empty {
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.candidate-card strong {
+    font-size: 1.05rem;
+    color: var(--primary-dark);
+}
+
+.candidate-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    font-size: 0.9rem;
+    color: var(--muted);
+}
+
+.candidate-meta span {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: rgba(91, 91, 207, 0.1);
+    color: var(--primary-dark);
+    padding: 6px 12px;
+    border-radius: 999px;
+}
+
+.candidate-score {
+    font-weight: 600;
+    color: #1a8654;
+}
+
+.candidate-added {
+    font-size: 0.85rem;
+    color: var(--muted);
+}
+
+.process-grid {
+    display: grid;
+    gap: 32px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.process-step {
+    background: var(--card-bg);
+    padding: 24px;
+    border-radius: 20px;
+    box-shadow: var(--shadow);
+    position: relative;
+}
+
+.process-step span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: var(--primary);
+    color: white;
+    font-weight: 700;
+    margin-bottom: 16px;
+}
+
+.process-step p {
+    color: var(--muted);
+    line-height: 1.6;
+}
+
+.metrics {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.metric-card {
+    background: linear-gradient(145deg, #ffffff 0%, #f3f3ff 100%);
+    border-radius: 20px;
+    padding: 24px;
+    text-align: center;
+    box-shadow: var(--shadow);
+}
+
+.metric-card h3 {
+    font-size: 2rem;
+    margin: 0 0 8px;
+    color: var(--primary-dark);
+}
+
+.metric-card p {
+    margin: 0;
+    color: var(--muted);
+}
+
+.testimonial-grid {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.testimonial {
+    background: var(--card-bg);
+    border-radius: 20px;
+    padding: 28px;
+    box-shadow: var(--shadow);
+    position: relative;
+}
+
+.testimonial::before {
+    content: "\201C";
+    font-size: 4rem;
+    color: rgba(91, 91, 207, 0.2);
+    position: absolute;
+    top: -24px;
+    left: 24px;
+}
+
+.testimonial p {
+    color: var(--muted);
+    line-height: 1.6;
+}
+
+.testimonial strong {
+    display: block;
+    margin-top: 16px;
+    color: var(--primary-dark);
+}
+
+.cta-section {
+    background: linear-gradient(135deg, #5b5bcf 0%, #8b60ff 100%);
+    border-radius: 28px;
+    padding: 56px 48px;
+    color: white;
+    text-align: center;
+    box-shadow: var(--shadow);
+}
+
+.cta-section h2 {
+    font-size: clamp(2rem, 4vw, 2.6rem);
+    margin-bottom: 16px;
+}
+
+.cta-section p {
+    margin-bottom: 28px;
+    line-height: 1.6;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.cta-section .button {
+    background: white;
+    color: var(--primary-dark);
+    box-shadow: none;
+}
+
+footer {
+    padding: 48px 0;
+    color: var(--muted);
+    text-align: center;
+    font-size: 0.9rem;
+}
+
+footer a {
+    color: inherit;
+}
+
+@media (max-width: 720px) {
+    nav ul {
+        display: none;
+    }
+
+    header {
+        padding-bottom: 56px;
+    }
+
+    .hero-card {
+        order: -1;
+    }
+}
+
+.hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+    margin-top: 28px;
+}
+
+.button-secondary {
+    background: rgba(91, 91, 207, 0.12);
+    color: var(--primary-dark);
+    box-shadow: none;
+}
+
+.button-secondary:hover,
+.button-secondary:focus {
+    background: rgba(91, 91, 207, 0.2);
+    color: var(--primary-dark);
+    box-shadow: none;
+}
+
+nav ul li a.is-active {
+    color: var(--primary-dark);
+    position: relative;
+}
+
+nav ul li a.is-active::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -6px;
+    width: 100%;
+    height: 2px;
+    background: var(--primary);
+    border-radius: 999px;
+}
+
+.page-hero {
+    display: grid;
+    gap: 20px;
+    max-width: 720px;
+}
+
+.page-hero h1 {
+    margin: 0;
+    font-size: clamp(2.2rem, 5vw, 3rem);
+}
+
+.page-hero p {
+    color: var(--muted);
+    line-height: 1.6;
+    margin: 0;
+}
+
+.muted {
+    color: var(--muted);
+}
+
+.card {
+    background: var(--card-bg);
+    border-radius: 24px;
+    padding: 28px;
+    box-shadow: var(--shadow);
+    display: grid;
+    gap: 20px;
+}
+
+.card-header h2 {
+    margin: 0;
+}
+
+.card-header p {
+    margin: 0;
+}
+
+.screening-workspace {
+    background: #ffffff;
+}
+
+.workspace-grid {
+    display: grid;
+    gap: 32px;
+}
+
+.workspace-column {
+    display: grid;
+    gap: 32px;
+    align-content: start;
+}
+
+.form-grid {
+    display: grid;
+    gap: 16px;
+}
+
+@media (min-width: 640px) {
+    .form-grid {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+}
+
+.question-builder {
+    display: grid;
+    gap: 16px;
+    border: 1px dashed rgba(91, 91, 207, 0.25);
+    border-radius: 16px;
+    padding: 16px;
+    background: rgba(91, 91, 207, 0.05);
+}
+
+.question-builder-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+}
+
+.text-button {
+    background: none;
+    border: none;
+    color: var(--primary-dark);
+    font-weight: 600;
+    cursor: pointer;
+    padding: 0;
+}
+
+.text-button:hover,
+.text-button:focus {
+    text-decoration: underline;
+}
+
+.question-list {
+    display: grid;
+    gap: 12px;
+}
+
+.question-item {
+    display: grid;
+    gap: 8px;
+    background: white;
+    border-radius: 14px;
+    padding: 16px;
+    border: 1px solid rgba(91, 91, 207, 0.18);
+}
+
+.question-item label {
+    font-weight: 600;
+}
+
+.remove-question {
+    justify-self: start;
+    background: none;
+    border: none;
+    color: var(--muted);
+    font-weight: 600;
+    cursor: pointer;
+    padding: 0;
+}
+
+.remove-question:hover,
+.remove-question:focus {
+    color: #c93c3c;
+}
+
+.input-help {
+    color: var(--muted);
+    font-size: 0.85rem;
+}
+
+.requirements-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 8px;
+}
+
+.requirements-list li {
+    background: rgba(91, 91, 207, 0.08);
+    color: var(--primary-dark);
+    padding: 8px 12px;
+    border-radius: 12px;
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+.question-preview {
+    margin: 0;
+    padding-left: 20px;
+    display: grid;
+    gap: 6px;
+}
+
+.active-summary {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.active-stacks {
+    display: grid;
+    gap: 20px;
+}
+
+.dynamic-questions {
+    display: grid;
+    gap: 16px;
+}
+
+.review-card {
+    gap: 24px;
+}
+
+.review-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: flex-start;
+}
+
+.review-stats {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.stat-badge {
+    background: rgba(91, 91, 207, 0.12);
+    color: var(--primary-dark);
+    padding: 6px 14px;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.empty-state {
+    background: rgba(91, 91, 207, 0.08);
+    color: var(--muted);
+    border-radius: 16px;
+    padding: 16px;
+    font-weight: 600;
+}
+
+.review-content {
+    display: grid;
+    gap: 16px;
+}
+
+.review-card .candidate-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    color: var(--muted);
+}
+
+.answer-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 8px;
+}
+
+.answer-list li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: rgba(91, 91, 207, 0.08);
+    padding: 10px 14px;
+    border-radius: 12px;
+    font-weight: 600;
+}
+
+.answer-list span {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.review-actions {
+    display: flex;
+    gap: 12px;
+}
+
+.intake-form.is-disabled {
+    opacity: 0.55;
+}
+
+.intake-form.is-disabled input,
+.intake-form.is-disabled textarea,
+.intake-form.is-disabled button {
+    pointer-events: none;
+}
+
+button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    box-shadow: none !important;
+    transform: none !important;
+}
+
+.contact-grid {
+    display: grid;
+    gap: 32px;
+}
+
+.contact-copy {
+    display: grid;
+    gap: 16px;
+}
+
+.contact-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 8px;
+    font-weight: 600;
+}
+
+.contact-form {
+    background: linear-gradient(145deg, #ffffff 0%, #f3f3ff 100%);
+    border-radius: 24px;
+    padding: 32px;
+    box-shadow: var(--shadow);
+}
+
+@media (min-width: 992px) {
+    .workspace-grid {
+        grid-template-columns: 360px 1fr;
+    }
+
+    .contact-grid {
+        grid-template-columns: 1fr 1fr;
+        align-items: start;
+    }
+}
+
+@media (max-width: 720px) {
+    nav {
+        flex-direction: column;
+        gap: 24px;
+    }
+
+    nav ul {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 12px;
+    }
+
+    .hero {
+        text-align: center;
+    }
+
+    .hero-actions {
+        justify-content: center;
+    }
+
+    .review-header {
+        flex-direction: column;
+    }
+
+    .review-actions {
+        flex-direction: column;
+    }
+}
+
+.recruitment-list {
+    display: grid;
+    gap: 16px;
+}
+
+.recruitment-entry {
+    border: 1px solid rgba(91, 91, 207, 0.16);
+    border-radius: 18px;
+    padding: 18px;
+    background: linear-gradient(145deg, #ffffff 0%, #f3f3ff 100%);
+    display: grid;
+    gap: 12px;
+}
+
+.recruitment-entry.is-active {
+    border-color: var(--primary);
+    box-shadow: 0 16px 40px rgba(91, 91, 207, 0.18);
+}
+
+.recruitment-entry header {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    align-items: flex-start;
+}
+
+.recruitment-entry h3 {
+    margin: 0;
+    font-size: 1.1rem;
+}
+
+.recruitment-entry p {
+    margin: 0;
+    color: var(--muted);
+}
+
+.recruitment-entry .entry-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.recruitment-entry button {
+    justify-self: start;
+    padding: 8px 16px;
+    border-radius: 999px;
+    border: none;
+    background: var(--primary);
+    color: white;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: var(--shadow);
+}
+
+.recruitment-entry.is-active button {
+    background: rgba(91, 91, 207, 0.12);
+    color: var(--primary-dark);
+    box-shadow: none;
+    cursor: default;
+}
+
+.recruitment-entry button:hover:not([disabled]),
+.recruitment-entry button:focus:not([disabled]) {
+    transform: translateY(-2px);
+}
+
+.recruitment-entry button {
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.candidate-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+}
+
+.score-badge {
+    background: rgba(26, 134, 84, 0.12);
+    color: #1a8654;
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.candidate-card time {
+    font-size: 0.85rem;
+    color: var(--muted);
+}
+
+.form-feedback.notice {
+    color: var(--primary-dark);
+}
+
+.footer-grid {
+    display: grid;
+    gap: 24px;
+    margin-bottom: 24px;
+}
+
+.footer-grid ul {
+    list-style: none;
+    padding: 0;
+    margin: 12px 0 0;
+    display: grid;
+    gap: 8px;
+}
+
+.footer-grid a {
+    text-decoration: none;
+}
+
+@media (min-width: 720px) {
+    .footer-grid {
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        text-align: left;
+    }
+}
+
+.recruitment-entry .entry-meta span {
+    background: rgba(91, 91, 207, 0.12);
+    color: var(--primary-dark);
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.85rem;
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,777 @@
+const yearEl = document.getElementById('year');
+if (yearEl) {
+    yearEl.textContent = new Date().getFullYear();
+}
+
+const page = document.body ? document.body.dataset.page : null;
+
+const storageAvailable = (() => {
+    try {
+        const testKey = '__tt_storage_test__';
+        window.localStorage.setItem(testKey, 'ok');
+        window.localStorage.removeItem(testKey);
+        return true;
+    } catch (error) {
+        console.warn('LocalStorage är inte tillgängligt. Data sparas endast under sessionen.', error);
+        return false;
+    }
+})();
+
+const showFeedback = (element, message, type) => {
+    if (!element) {
+        return;
+    }
+    element.textContent = message || '';
+    element.classList.remove('success', 'error', 'notice');
+    if (message && type) {
+        element.classList.add(type);
+    }
+};
+
+const initScreeningPage = () => {
+    const recruitmentForm = document.getElementById('recruitmentForm');
+    const questionListEl = document.getElementById('questionList');
+    const addQuestionBtn = document.getElementById('addQuestionButton');
+    const thresholdInput = document.getElementById('recruitmentThreshold');
+    const recruitmentFeedback = document.getElementById('recruitmentFeedback');
+    const recruitmentListEl = document.getElementById('recruitmentList');
+
+    const activeTitleEl = document.getElementById('activeRecruitmentTitle');
+    const activeMetaEl = document.getElementById('activeRecruitmentMeta');
+    const activeRoleEl = document.getElementById('activeRecruitmentRole');
+    const activeThresholdEl = document.getElementById('activeThreshold');
+    const activeRequirementsEl = document.getElementById('activeRequirements');
+    const activeQuestionListEl = document.getElementById('activeQuestionList');
+
+    const candidateForm = document.getElementById('candidateForm');
+    const candidateHelper = document.getElementById('candidateFormHelper');
+    const candidateQuestionFields = document.getElementById('candidateQuestionFields');
+    const candidateFeedback = document.getElementById('candidateFeedback');
+
+    const pipelineCountEl = document.getElementById('pipelineCount');
+    const acceptedCountEl = document.getElementById('acceptedCount');
+    const pipelineEmptyEl = document.getElementById('pipelineEmpty');
+    const reviewContentEl = document.getElementById('candidateReviewContent');
+    const acceptBtn = document.getElementById('acceptCandidateBtn');
+    const rejectBtn = document.getElementById('rejectCandidateBtn');
+    const reviewFeedback = document.getElementById('reviewFeedback');
+
+    if (!recruitmentForm || !questionListEl || !addQuestionBtn || !thresholdInput || !recruitmentListEl || !candidateForm) {
+        return;
+    }
+
+    const STORAGE_KEY = 'tandemTalentRecruitmentsV1';
+    const MIN_QUESTIONS = 3;
+    const MAX_QUESTIONS = 6;
+    const DEFAULT_QUESTIONS = [
+        'Har du minst ett års erfarenhet inom området?',
+        'Kan du börja inom 30 dagar?',
+        'Kan du arbeta skift eller kväll vid behov?',
+        'Har du relevanta certifikat eller behörigheter?',
+        'Talar du svenska på yrkesmässig nivå?',
+    ];
+
+    let questionCounter = 0;
+
+    const state = {
+        recruitments: [],
+        activeRecruitmentId: null,
+    };
+
+    const normalizeCandidate = (candidate) => ({
+        id: candidate.id,
+        name: candidate.name,
+        experience: candidate.experience,
+        location: candidate.location,
+        pitch: candidate.pitch,
+        answers: Array.isArray(candidate.answers) ? candidate.answers : [],
+        positiveCount: candidate.positiveCount || 0,
+        score: candidate.score || 0,
+        submittedAt: candidate.submittedAt || new Date().toISOString(),
+    });
+
+    const normalizeRecruitment = (entry) => ({
+        id: entry.id,
+        name: entry.name,
+        role: entry.role,
+        location: entry.location,
+        threshold: entry.threshold || MIN_QUESTIONS,
+        requirements: Array.isArray(entry.requirements) ? entry.requirements : [],
+        questions: Array.isArray(entry.questions) ? entry.questions : [],
+        pipeline: Array.isArray(entry.pipeline) ? entry.pipeline.map(normalizeCandidate) : [],
+        accepted: Array.isArray(entry.accepted) ? entry.accepted.map(normalizeCandidate) : [],
+        rejected: Array.isArray(entry.rejected) ? entry.rejected.map(normalizeCandidate) : [],
+        createdAt: entry.createdAt || new Date().toISOString(),
+    });
+
+    const createDefaultState = () => {
+        const defaultRecruitment = {
+            id: 'rec-default',
+            name: 'Lagerteam Göteborg',
+            role: 'Lagermedarbetare',
+            location: 'Göteborg',
+            threshold: 4,
+            requirements: [
+                'Minst 1 års erfarenhet av lagerarbete',
+                'Giltigt truckkort A-B',
+                'Kan arbeta skift och kväll vid behov',
+            ],
+            questions: [
+                { id: 'q1', text: 'Har du arbetat med lagerhantering minst ett år?' },
+                { id: 'q2', text: 'Kan du börja inom 30 dagar?' },
+                { id: 'q3', text: 'Kan du arbeta skift eller kväll?' },
+                { id: 'q4', text: 'Har du giltigt truckkort eller motsvarande certifiering?' },
+                { id: 'q5', text: 'Talar du svenska på yrkesmässig nivå?' },
+            ],
+            pipeline: [
+                normalizeCandidate({
+                    id: 'cand-demo',
+                    name: 'Emilia Larsson',
+                    experience: 4,
+                    location: 'Göteborg',
+                    pitch: 'Logistikdriven lagerspecialist som trivs i högt tempo.',
+                    answers: [
+                        { id: 'q1', text: 'Har du arbetat med lagerhantering minst ett år?', value: 'ja' },
+                        { id: 'q2', text: 'Kan du börja inom 30 dagar?', value: 'ja' },
+                        { id: 'q3', text: 'Kan du arbeta skift eller kväll?', value: 'ja' },
+                        { id: 'q4', text: 'Har du giltigt truckkort eller motsvarande certifiering?', value: 'ja' },
+                        { id: 'q5', text: 'Talar du svenska på yrkesmässig nivå?', value: 'ja' },
+                    ],
+                    positiveCount: 5,
+                    score: 100,
+                    submittedAt: new Date().toISOString(),
+                }),
+            ],
+            accepted: [],
+            rejected: [],
+            createdAt: new Date().toISOString(),
+        };
+
+        return {
+            recruitments: [defaultRecruitment],
+            activeRecruitmentId: defaultRecruitment.id,
+        };
+    };
+
+    const loadState = () => {
+        if (!storageAvailable) {
+            Object.assign(state, createDefaultState());
+            return;
+        }
+
+        try {
+            const stored = window.localStorage.getItem(STORAGE_KEY);
+            if (!stored) {
+                Object.assign(state, createDefaultState());
+                return;
+            }
+
+            const parsed = JSON.parse(stored);
+            if (!parsed || !Array.isArray(parsed.recruitments)) {
+                throw new Error('Ogiltig lagrad struktur');
+            }
+
+            state.recruitments = parsed.recruitments.map(normalizeRecruitment);
+            state.activeRecruitmentId = parsed.activeRecruitmentId || (state.recruitments[0] ? state.recruitments[0].id : null);
+
+            if (!state.recruitments.length) {
+                Object.assign(state, createDefaultState());
+            }
+        } catch (error) {
+            console.warn('Kunde inte läsa rekryteringar från lagring.', error);
+            Object.assign(state, createDefaultState());
+        }
+    };
+
+    const saveState = () => {
+        if (!storageAvailable) {
+            return;
+        }
+
+        try {
+            window.localStorage.setItem(
+                STORAGE_KEY,
+                JSON.stringify({
+                    recruitments: state.recruitments,
+                    activeRecruitmentId: state.activeRecruitmentId,
+                }),
+            );
+        } catch (error) {
+            console.warn('Kunde inte spara rekryteringar till lagring.', error);
+        }
+    };
+
+    const getActiveRecruitment = () => state.recruitments.find((recruitment) => recruitment.id === state.activeRecruitmentId) || null;
+
+    const createMetaChip = (text) => {
+        const span = document.createElement('span');
+        span.textContent = text;
+        return span;
+    };
+
+    const updateQuestionControls = () => {
+        const items = Array.from(questionListEl.querySelectorAll('.question-item'));
+        items.forEach((item, index) => {
+            const label = item.querySelector('label');
+            if (label) {
+                label.textContent = `Fråga ${index + 1}`;
+            }
+            const removeBtn = item.querySelector('.remove-question');
+            if (removeBtn) {
+                const disable = items.length <= MIN_QUESTIONS;
+                removeBtn.disabled = disable;
+                removeBtn.style.visibility = disable ? 'hidden' : 'visible';
+            }
+        });
+
+        if (addQuestionBtn) {
+            addQuestionBtn.disabled = items.length >= MAX_QUESTIONS;
+        }
+
+        if (thresholdInput) {
+            const maxQuestions = Math.max(items.length, MIN_QUESTIONS);
+            thresholdInput.max = String(maxQuestions);
+            if (Number(thresholdInput.value) > maxQuestions) {
+                thresholdInput.value = String(maxQuestions);
+            }
+        }
+    };
+
+    const createQuestionField = (value = '') => {
+        questionCounter += 1;
+        const wrapper = document.createElement('div');
+        wrapper.className = 'question-item';
+        wrapper.dataset.questionId = `builder-${questionCounter}`;
+
+        const label = document.createElement('label');
+        label.setAttribute('for', `question-${questionCounter}`);
+        label.textContent = `Fråga ${questionCounter}`;
+
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.id = `question-${questionCounter}`;
+        input.name = `question-${questionCounter}`;
+        input.required = true;
+        input.placeholder = 'Ex. Kan du arbeta skift?';
+        input.value = value;
+
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.className = 'remove-question';
+        removeBtn.textContent = 'Ta bort';
+        removeBtn.addEventListener('click', () => {
+            wrapper.remove();
+            updateQuestionControls();
+        });
+
+        wrapper.append(label, input, removeBtn);
+        questionListEl.appendChild(wrapper);
+        updateQuestionControls();
+    };
+
+    const resetRecruitmentForm = () => {
+        recruitmentForm.reset();
+        questionListEl.innerHTML = '';
+        questionCounter = 0;
+        DEFAULT_QUESTIONS.forEach((question) => createQuestionField(question));
+        thresholdInput.value = String(Math.min(4, DEFAULT_QUESTIONS.length));
+        updateQuestionControls();
+        showFeedback(recruitmentFeedback, '');
+    };
+
+    const renderRecruitmentList = () => {
+        recruitmentListEl.innerHTML = '';
+
+        if (!state.recruitments.length) {
+            const empty = document.createElement('p');
+            empty.className = 'empty-state';
+            empty.textContent = 'Inga rekryteringar ännu. Skapa din första för att börja samla kandidater.';
+            recruitmentListEl.appendChild(empty);
+            return;
+        }
+
+        state.recruitments.forEach((recruitment) => {
+            const isActive = recruitment.id === state.activeRecruitmentId;
+            const entry = document.createElement('article');
+            entry.className = `recruitment-entry${isActive ? ' is-active' : ''}`;
+
+            const header = document.createElement('header');
+            const title = document.createElement('h3');
+            title.textContent = recruitment.name;
+
+            const button = document.createElement('button');
+            button.type = 'button';
+            if (isActive) {
+                button.textContent = 'Aktiv';
+                button.disabled = true;
+            } else {
+                button.textContent = 'Välj';
+                button.addEventListener('click', () => {
+                    state.activeRecruitmentId = recruitment.id;
+                    saveState();
+                    renderActiveSummary();
+                    renderPipeline();
+                    renderRecruitmentList();
+                });
+            }
+
+            header.append(title, button);
+
+            const meta = document.createElement('div');
+            meta.className = 'entry-meta';
+            meta.append(
+                createMetaChip(`🎯 ${recruitment.role}`),
+                createMetaChip(`📍 ${recruitment.location}`),
+                createMetaChip(`Tröskel: ${recruitment.threshold}`),
+            );
+
+            const stats = document.createElement('p');
+            stats.innerHTML = `<strong>${recruitment.pipeline.length}</strong> i kö · <strong>${recruitment.accepted.length}</strong> accepterade`;
+
+            entry.append(header, meta, stats);
+            recruitmentListEl.appendChild(entry);
+        });
+    };
+
+    const renderCandidateQuestions = (recruitment) => {
+        candidateQuestionFields.innerHTML = '';
+        if (!recruitment) {
+            return;
+        }
+
+        recruitment.questions.forEach((question) => {
+            const fieldset = document.createElement('fieldset');
+            const legend = document.createElement('legend');
+            legend.textContent = question.text;
+
+            const options = document.createElement('div');
+            options.className = 'radio-options';
+
+            const yesId = `candidate-${question.id}-yes`;
+            const noId = `candidate-${question.id}-no`;
+
+            const yesLabel = document.createElement('label');
+            yesLabel.className = 'radio-pill';
+            const yesInput = document.createElement('input');
+            yesInput.type = 'radio';
+            yesInput.name = `question-${question.id}`;
+            yesInput.id = yesId;
+            yesInput.value = 'ja';
+            yesInput.required = true;
+            const yesSpan = document.createElement('span');
+            yesSpan.textContent = 'Ja';
+            yesLabel.append(yesInput, yesSpan);
+
+            const noLabel = document.createElement('label');
+            noLabel.className = 'radio-pill';
+            const noInput = document.createElement('input');
+            noInput.type = 'radio';
+            noInput.name = `question-${question.id}`;
+            noInput.id = noId;
+            noInput.value = 'nej';
+            noInput.required = true;
+            const noSpan = document.createElement('span');
+            noSpan.textContent = 'Nej';
+            noLabel.append(noInput, noSpan);
+
+            options.append(yesLabel, noLabel);
+            fieldset.append(legend, options);
+            candidateQuestionFields.appendChild(fieldset);
+        });
+    };
+
+    const setCandidateFormAvailability = (recruitment) => {
+        const isActive = Boolean(recruitment);
+        const fields = candidateForm.querySelectorAll('input, textarea, select');
+        fields.forEach((field) => {
+            field.disabled = !isActive;
+        });
+        const submitButton = candidateForm.querySelector('button[type="submit"]');
+        if (submitButton) {
+            submitButton.disabled = !isActive;
+        }
+        candidateForm.classList.toggle('is-disabled', !isActive);
+
+        if (!isActive) {
+            candidateHelper.textContent = 'Välj en rekrytering för att aktivera formuläret.';
+            candidateForm.reset();
+            candidateQuestionFields.innerHTML = '';
+            showFeedback(candidateFeedback, '');
+            return;
+        }
+
+        candidateHelper.textContent = `Aktiv rekrytering: ${recruitment.name}. Minst ${recruitment.threshold} "ja" krävs.`;
+        candidateForm.reset();
+        renderCandidateQuestions(recruitment);
+        showFeedback(candidateFeedback, '');
+    };
+
+    const renderActiveSummary = () => {
+        const recruitment = getActiveRecruitment();
+        if (!recruitment) {
+            if (activeTitleEl) {
+                activeTitleEl.textContent = 'Ingen rekrytering vald';
+            }
+            if (activeMetaEl) {
+                activeMetaEl.textContent = 'Skapa eller välj en rekrytering för att se detaljer.';
+            }
+            if (activeRoleEl) {
+                activeRoleEl.textContent = '–';
+            }
+            if (activeThresholdEl) {
+                activeThresholdEl.textContent = '–';
+            }
+            if (activeRequirementsEl) {
+                activeRequirementsEl.innerHTML = '';
+            }
+            if (activeQuestionListEl) {
+                activeQuestionListEl.innerHTML = '';
+            }
+            setCandidateFormAvailability(null);
+            return;
+        }
+
+        if (activeTitleEl) {
+            activeTitleEl.textContent = recruitment.name;
+        }
+        if (activeMetaEl) {
+            const created = recruitment.createdAt ? new Date(recruitment.createdAt) : null;
+            activeMetaEl.textContent = created
+                ? `Skapad ${created.toLocaleDateString('sv-SE', { year: 'numeric', month: 'short', day: 'numeric' })}`
+                : 'Skapad i TandemTalent';
+        }
+        if (activeRoleEl) {
+            activeRoleEl.textContent = `${recruitment.role} • ${recruitment.location}`;
+        }
+        if (activeThresholdEl) {
+            activeThresholdEl.textContent = `${recruitment.threshold} av ${recruitment.questions.length} "ja"`;
+        }
+        if (activeRequirementsEl) {
+            activeRequirementsEl.innerHTML = '';
+            if (recruitment.requirements.length) {
+                recruitment.requirements.forEach((req) => {
+                    const li = document.createElement('li');
+                    li.textContent = req;
+                    activeRequirementsEl.appendChild(li);
+                });
+            } else {
+                const li = document.createElement('li');
+                li.textContent = 'Inga specifika krav angivna.';
+                activeRequirementsEl.appendChild(li);
+            }
+        }
+        if (activeQuestionListEl) {
+            activeQuestionListEl.innerHTML = '';
+            recruitment.questions.forEach((question) => {
+                const li = document.createElement('li');
+                li.textContent = question.text;
+                activeQuestionListEl.appendChild(li);
+            });
+        }
+
+        setCandidateFormAvailability(recruitment);
+    };
+
+    const renderPipeline = () => {
+        const recruitment = getActiveRecruitment();
+        const pipeline = recruitment ? recruitment.pipeline : [];
+
+        if (pipelineCountEl) {
+            pipelineCountEl.textContent = recruitment ? String(pipeline.length) : '0';
+        }
+        if (acceptedCountEl) {
+            acceptedCountEl.textContent = recruitment ? String(recruitment.accepted.length) : '0';
+        }
+
+        if (!recruitment || !pipeline.length) {
+            if (reviewContentEl) {
+                reviewContentEl.innerHTML = '';
+            }
+            if (pipelineEmptyEl) {
+                pipelineEmptyEl.style.display = 'block';
+            }
+            if (acceptBtn) {
+                acceptBtn.disabled = true;
+            }
+            if (rejectBtn) {
+                rejectBtn.disabled = true;
+            }
+            showFeedback(reviewFeedback, '');
+            return;
+        }
+
+        if (pipelineEmptyEl) {
+            pipelineEmptyEl.style.display = 'none';
+        }
+        if (acceptBtn) {
+            acceptBtn.disabled = false;
+        }
+        if (rejectBtn) {
+            rejectBtn.disabled = false;
+        }
+
+        const candidate = pipeline[0];
+        if (reviewContentEl) {
+            reviewContentEl.innerHTML = '';
+            const card = document.createElement('div');
+            card.className = 'candidate-card';
+
+            const header = document.createElement('div');
+            header.className = 'candidate-card-header';
+            const name = document.createElement('strong');
+            name.textContent = candidate.name;
+            const score = document.createElement('span');
+            score.className = 'score-badge';
+            score.textContent = `${candidate.score}% match`;
+            header.append(name, score);
+
+            const meta = document.createElement('p');
+            meta.className = 'candidate-meta';
+            meta.append(
+                createMetaChip(`🎯 ${recruitment.role}`),
+                createMetaChip(`📍 ${candidate.location}`),
+                createMetaChip(`🗓️ ${candidate.experience} år erfarenhet`),
+            );
+
+            const pitch = document.createElement('p');
+            pitch.textContent = candidate.pitch;
+
+            const answersList = document.createElement('ul');
+            answersList.className = 'answer-list';
+            candidate.answers.forEach((answer) => {
+                const li = document.createElement('li');
+                const questionSpan = document.createElement('span');
+                questionSpan.textContent = answer.text;
+                const valueSpan = document.createElement('span');
+                valueSpan.textContent = answer.value === 'ja' ? '✅ Ja' : '⛔ Nej';
+                li.append(questionSpan, valueSpan);
+                answersList.appendChild(li);
+            });
+
+            const submitted = document.createElement('time');
+            if (candidate.submittedAt) {
+                submitted.dateTime = candidate.submittedAt;
+                const submittedDate = new Date(candidate.submittedAt);
+                submitted.textContent = `Registrerad ${submittedDate.toLocaleDateString('sv-SE', {
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric',
+                })} kl. ${submittedDate.toLocaleTimeString('sv-SE', { hour: '2-digit', minute: '2-digit' })}`;
+            }
+
+            card.append(header, meta, pitch, answersList, submitted);
+            reviewContentEl.appendChild(card);
+        }
+
+        showFeedback(reviewFeedback, '');
+    };
+
+    const handleRecruitmentSubmit = (event) => {
+        event.preventDefault();
+        const formData = new FormData(recruitmentForm);
+
+        const name = (formData.get('name') || '').toString().trim();
+        const role = (formData.get('role') || '').toString().trim();
+        const location = (formData.get('location') || '').toString().trim();
+        const thresholdValueRaw = (formData.get('threshold') || '').toString().trim();
+        const requirementsRaw = (formData.get('requirements') || '').toString();
+
+        const questionInputs = Array.from(questionListEl.querySelectorAll("input[type='text']"));
+        const questions = questionInputs
+            .map((input) => input.value.trim())
+            .filter((value) => value.length);
+
+        if (!name || !role || !location) {
+            showFeedback(recruitmentFeedback, 'Fyll i namn, roll och ort för rekryteringen.', 'error');
+            return;
+        }
+
+        if (questions.length < MIN_QUESTIONS) {
+            showFeedback(recruitmentFeedback, `Lägg till minst ${MIN_QUESTIONS} frågor innan du sparar.`, 'error');
+            return;
+        }
+
+        const thresholdValue = Number(thresholdValueRaw || questions.length);
+        if (!Number.isFinite(thresholdValue) || thresholdValue < 1) {
+            showFeedback(recruitmentFeedback, 'Ange en giltig tröskel för antal "ja"-svar.', 'error');
+            return;
+        }
+
+        if (thresholdValue > questions.length) {
+            showFeedback(recruitmentFeedback, 'Tröskeln kan inte vara högre än antalet frågor.', 'error');
+            return;
+        }
+
+        const requirements = requirementsRaw
+            .split('\n')
+            .map((req) => req.trim())
+            .filter((req) => req.length);
+
+        const recruitment = {
+            id: `rec-${Date.now()}`,
+            name,
+            role,
+            location,
+            threshold: thresholdValue,
+            requirements,
+            questions: questions.map((text, index) => ({ id: `q${index + 1}`, text })),
+            pipeline: [],
+            accepted: [],
+            rejected: [],
+            createdAt: new Date().toISOString(),
+        };
+
+        state.recruitments = [recruitment, ...state.recruitments];
+        state.activeRecruitmentId = recruitment.id;
+        saveState();
+        renderRecruitmentList();
+        renderActiveSummary();
+        renderPipeline();
+        resetRecruitmentForm();
+        showFeedback(recruitmentFeedback, 'Rekryteringen sparades och sattes som aktiv.', 'success');
+    };
+
+    const handleCandidateSubmit = (event) => {
+        event.preventDefault();
+        const recruitment = getActiveRecruitment();
+        if (!recruitment) {
+            showFeedback(candidateFeedback, 'Välj en rekrytering innan du lägger till kandidater.', 'error');
+            return;
+        }
+
+        const formData = new FormData(candidateForm);
+        const name = (formData.get('name') || '').toString().trim();
+        const experienceValue = (formData.get('experience') || '').toString().trim();
+        const location = (formData.get('location') || '').toString().trim();
+        const pitch = (formData.get('pitch') || '').toString().trim();
+
+        if (!name || !experienceValue || !location || !pitch) {
+            showFeedback(candidateFeedback, 'Fyll i samtliga fält innan du skickar in kandidaten.', 'error');
+            return;
+        }
+
+        const experience = Number(experienceValue);
+        if (!Number.isFinite(experience) || experience < 0) {
+            showFeedback(candidateFeedback, 'Ange erfarenhet i år som ett heltal 0 eller större.', 'error');
+            return;
+        }
+
+        const answers = [];
+        for (const question of recruitment.questions) {
+            const value = formData.get(`question-${question.id}`);
+            if (!value) {
+                showFeedback(candidateFeedback, 'Besvara alla screeningfrågor.', 'error');
+                return;
+            }
+            answers.push({ id: question.id, text: question.text, value: value.toString() });
+        }
+
+        const positiveCount = answers.filter((answer) => answer.value === 'ja').length;
+        if (positiveCount < recruitment.threshold) {
+            showFeedback(
+                candidateFeedback,
+                `Kandidaten fick ${positiveCount} av ${recruitment.questions.length} "ja" och stoppas innan rekryterarvyn.`,
+                'error',
+            );
+            candidateForm.reset();
+            renderCandidateQuestions(recruitment);
+            const nameField = document.getElementById('candidateName');
+            if (nameField) {
+                nameField.focus();
+            }
+            return;
+        }
+
+        const candidate = {
+            id: `cand-${Date.now()}`,
+            name,
+            experience,
+            location,
+            pitch,
+            answers,
+            positiveCount,
+            score: Math.round((positiveCount / recruitment.questions.length) * 100),
+            submittedAt: new Date().toISOString(),
+        };
+
+        recruitment.pipeline.push(candidate);
+        saveState();
+        renderPipeline();
+        renderRecruitmentList();
+        candidateForm.reset();
+        renderCandidateQuestions(recruitment);
+        showFeedback(candidateFeedback, 'Kandidaten kvalificerades och lades till i rekryterarvyn.', 'success');
+        const nameField = document.getElementById('candidateName');
+        if (nameField) {
+            nameField.focus();
+        }
+    };
+
+    const handleDecision = (decision) => {
+        const recruitment = getActiveRecruitment();
+        if (!recruitment || !recruitment.pipeline.length) {
+            return;
+        }
+
+        const candidate = recruitment.pipeline.shift();
+        const targetCollection = decision === 'accept' ? recruitment.accepted : recruitment.rejected;
+        targetCollection.push({ ...candidate, decidedAt: new Date().toISOString() });
+
+        saveState();
+        renderPipeline();
+        renderRecruitmentList();
+        if (decision === 'accept') {
+            showFeedback(reviewFeedback, `${candidate.name} markerades som klar för nästa steg.`, 'success');
+        } else {
+            showFeedback(reviewFeedback, `${candidate.name} togs bort från flödet.`, 'notice');
+        }
+    };
+
+    addQuestionBtn.addEventListener('click', () => createQuestionField());
+    recruitmentForm.addEventListener('submit', handleRecruitmentSubmit);
+    candidateForm.addEventListener('submit', handleCandidateSubmit);
+
+    if (acceptBtn) {
+        acceptBtn.addEventListener('click', () => handleDecision('accept'));
+    }
+    if (rejectBtn) {
+        rejectBtn.addEventListener('click', () => handleDecision('reject'));
+    }
+
+    loadState();
+    resetRecruitmentForm();
+    renderRecruitmentList();
+    renderActiveSummary();
+    renderPipeline();
+};
+
+const initContactPage = () => {
+    const form = document.getElementById('contactForm');
+    const feedback = document.getElementById('contactFeedback');
+    if (!form || !feedback) {
+        return;
+    }
+
+    form.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const formData = new FormData(form);
+        const name = (formData.get('name') || '').toString().trim();
+        const email = (formData.get('email') || '').toString().trim();
+
+        if (!name || !email) {
+            showFeedback(feedback, 'Fyll i namn och e-post för att boka en demo.', 'error');
+            return;
+        }
+
+        showFeedback(feedback, 'Tack! Vi återkommer inom 24 timmar med en demo.', 'success');
+        form.reset();
+    });
+};
+
+if (page === 'screening') {
+    initScreeningPage();
+}
+
+if (page === 'kontakt') {
+    initContactPage();
+}

--- a/case.html
+++ b/case.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kundcase – TandemTalent</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body data-page="case">
+    <header>
+        <div class="container">
+            <nav>
+                <a href="index.html" class="logo" aria-label="TandemTalent startsida">
+                    <span>TT</span>
+                    TandemTalent
+                </a>
+                <ul>
+                    <li><a href="losning.html">Lösningen</a></li>
+                    <li><a href="process.html">Så funkar det</a></li>
+                    <li><a href="screening.html">Kandidatintag</a></li>
+                    <li><a href="case.html" class="is-active">Kundcase</a></li>
+                    <li><a href="kontakt.html">Boka demo</a></li>
+                </ul>
+                <a href="kontakt.html" class="button">Boka demo</a>
+            </nav>
+            <div class="page-hero">
+                <h1>Byråer som redan matchar rätt med TandemTalent</h1>
+                <p>
+                    Från nischade logistikuppdrag till tech-team i hypergrowth – våra kunder använder TandemTalent för att leverera shortlist på rekordtid.
+                </p>
+                <div class="hero-actions">
+                    <a href="screening.html" class="button">Se hur vi screenar</a>
+                    <a href="kontakt.html" class="button button-secondary">Boka demo</a>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section>
+            <div class="container">
+                <div class="section-header">
+                    <h2>Kundcase</h2>
+                    <p>
+                        Se hur rekryteringsbyråer använder TandemTalent för att vinna fler uppdrag, skapa bättre kandidatupplevelse och leverera snabbare.
+                    </p>
+                </div>
+                <div class="testimonial-grid">
+                    <article class="testimonial">
+                        <p>
+                            "Med TandemTalent kan våra konsultchefer se exakt vilka kandidater som finns tillgängliga och swipa fram en shortlist på minuter. Vi har halverat vår tid till kundpresentation."
+                        </p>
+                        <strong>Petra Holm, VD på Nordic Logistics Rekrytering</strong>
+                    </article>
+                    <article class="testimonial">
+                        <p>
+                            "Vi får färdiga kandidatkort som känns personliga och ger ett professionellt första intryck. Att matchningsgraden redan är satt gör att vi vågar gå till kund snabbare."
+                        </p>
+                        <strong>Jonas Ek, Team Lead, PeopleFirst</strong>
+                    </article>
+                    <article class="testimonial">
+                        <p>
+                            "Systemet gör gallringen åt oss. Rekryterarna älskar swipe-funktionen, och kandidaterna uppskattar hur snabbt vi återkopplar."
+                        </p>
+                        <strong>Mira Das, Operativ chef, Talentera</strong>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section style="background: #ffffff;">
+            <div class="container">
+                <div class="section-header">
+                    <h2>Resultat som sticker ut</h2>
+                    <p>Exempel på vad våra kunder rapporterat efter att ha lanserat TandemTalent.</p>
+                </div>
+                <div class="metrics">
+                    <div class="metric-card">
+                        <h3>50%</h3>
+                        <p>Kortare tid från första kontakt till signerat avtal.</p>
+                    </div>
+                    <div class="metric-card">
+                        <h3>+35%</h3>
+                        <p>Ökad kandidatnöjdhet genom snabb återkoppling och tydlig kommunikation.</p>
+                    </div>
+                    <div class="metric-card">
+                        <h3>2x</h3>
+                        <p>Fler parallella uppdrag per rekryterare tack vare automatiserad screening.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <div class="container">
+            <div class="footer-grid">
+                <div>
+                    <strong>TandemTalent</strong>
+                    <p>Rekryteringsplattformen som kombinerar smart matchning med en dejtingapp-känsla.</p>
+                </div>
+                <div>
+                    <strong>Utforska</strong>
+                    <ul>
+                        <li><a href="losning.html">Lösningen</a></li>
+                        <li><a href="process.html">Processen</a></li>
+                        <li><a href="screening.html">Kandidatintag</a></li>
+                        <li><a href="case.html" class="is-active">Kundcase</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <strong>Kontakt</strong>
+                    <ul>
+                        <li><a href="mailto:hej@tandemtalent.se">hej@tandemtalent.se</a></li>
+                        <li><a href="tel:+46101234567">+46 (0)10 123 45 67</a></li>
+                        <li><a href="kontakt.html">Boka demo</a></li>
+                    </ul>
+                </div>
+            </div>
+            <p>&copy; <span id="year"></span> TandemTalent. Skapad för rekryteringsbyråer som vill ligga steget före.</p>
+        </div>
+    </footer>
+
+    <script src="assets/js/app.js" defer></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,11 +1,289 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="sv">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TandemTalent – Rekrytering som känns som matchning</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
 </head>
-<body>
-    
+<body data-page="home">
+    <header>
+        <div class="container">
+            <nav>
+                <a href="index.html" class="logo" aria-label="TandemTalent startsida">
+                    <span>TT</span>
+                    TandemTalent
+                </a>
+                <ul>
+                    <li><a href="losning.html">Lösningen</a></li>
+                    <li><a href="process.html">Så funkar det</a></li>
+                    <li><a href="screening.html">Kandidatintag</a></li>
+                    <li><a href="case.html">Kundcase</a></li>
+                    <li><a href="kontakt.html">Boka demo</a></li>
+                </ul>
+                <a href="kontakt.html" class="button">Boka demo</a>
+            </nav>
+            <div class="hero">
+                <div>
+                    <h1>Möt kandidater som är redo för nästa steg – innan konkurrenten gör det</h1>
+                    <p>
+                        TandemTalent är rekryteringsplattformen som kombinerar matchningsteknik med en dejtingapp-känsla.
+                        Vi samlar, förkvalificerar och presenterar kandidater så att dina rekryterare kan fokusera på det
+                        de gör bäst: att skapa relationer.
+                    </p>
+                    <div class="hero-actions">
+                        <a href="screening.html" class="button">Testa screeningflödet</a>
+                        <a href="kontakt.html" class="button button-secondary">Prata med oss</a>
+                    </div>
+                </div>
+                <div class="hero-card" aria-label="Exempel på kandidatvy">
+                    <div class="profile-card">
+                        <div class="profile-header">
+                            <div class="profile-avatar" aria-hidden="true">👩‍🔧</div>
+                            <div>
+                                <strong>Emilia Larsson</strong>
+                                <p style="margin: 4px 0; color: var(--muted);">Lagerspecialist • Göteborg</p>
+                                <div class="tag">Matchning: 94%</div>
+                            </div>
+                        </div>
+                        <p>
+                            "Jag drivs av att få logistik att flyta smidigt och vill in i ett team med högt tempo och tydliga mål."
+                        </p>
+                        <div>
+                            <strong>Nyckelkompetenser</strong>
+                            <p style="margin: 6px 0 0; color: var(--muted);">
+                                Truckkort A-B · Lean-processer · Ledarskap i skiftlag
+                            </p>
+                        </div>
+                        <div class="swipe-actions" aria-hidden="true">
+                            <button class="swipe-button no">Passa</button>
+                            <button class="swipe-button yes">Boka samtal</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section>
+            <div class="container">
+                <div class="section-header">
+                    <h2>En kandidatpipeline som alltid är redo att swipas</h2>
+                    <p>
+                        Vi bygger upp ett uppdaterat kandidatnätverk inom era prioriterade roller. Varje kandidat matchas mot
+                        era kravprofiler och presenteras i ett enkelt kortformat där rekryterarna snabbt ser drivkrafter,
+                        kompetens och nästa steg.
+                    </p>
+                </div>
+                <div class="feature-grid">
+                    <article class="feature-card">
+                        <div class="feature-icon" aria-hidden="true">🤝</div>
+                        <h3>Smart matchning</h3>
+                        <p>
+                            Våra algoritmer väger samman erfarenhet, kompetens, personlig motivation och era must-haves för
+                            att bara visa relevanta kandidater.
+                        </p>
+                    </article>
+                    <article class="feature-card">
+                        <div class="feature-icon" aria-hidden="true">🗂️</div>
+                        <h3>Kandidatkort som säljer in</h3>
+                        <p>
+                            Genomtänkta profiler med foto, personligt statement, styrkor och rekommenderade nästa steg gör det
+                            enkelt att gå från intresse till kontakt.
+                        </p>
+                    </article>
+                    <article class="feature-card">
+                        <div class="feature-icon" aria-hidden="true">⚙️</div>
+                        <h3>Automatisk förkvalificering</h3>
+                        <p>
+                            Kandidater som inte matchar er kravprofil sorteras bort redan innan de visas, vilket sparar tid och
+                            skapar bättre kandidat- och rekryterarupplevelse.
+                        </p>
+                    </article>
+                    <article class="feature-card">
+                        <div class="feature-icon" aria-hidden="true">📊</div>
+                        <h3>Insikter i realtid</h3>
+                        <p>
+                            Följ pipelines, svarsfrekvens och tid till anställning i realtid. Dela insikter med kunder och få ett
+                            faktabaserat beslutsstöd.
+                        </p>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section style="background: #ffffff;">
+            <div class="container">
+                <div class="section-header">
+                    <h2>Så tar vi er från behov till signerad kandidat</h2>
+                    <p>
+                        Med TandemTalent blir rekrytering en upplevelse med tempo. Vi driver flödet så att ni kan fokusera på kund- och kandidatdialogen.
+                    </p>
+                </div>
+                <div class="process-grid">
+                    <article class="process-step">
+                        <span>1</span>
+                        <h3>Profilworkshop</h3>
+                        <p>
+                            Tillsammans ringar vi in vilka roller, kompetenser och mjuka värden som ska prioriteras i er pipeline.
+                        </p>
+                    </article>
+                    <article class="process-step">
+                        <span>2</span>
+                        <h3>Talent sourcing &amp; pre-screening</h3>
+                        <p>
+                            Vi skapar en skräddarsydd kampanj, samlar in kandidatdata och gör första urvalet baserat på era kriterier.
+                        </p>
+                    </article>
+                    <article class="process-step">
+                        <span>3</span>
+                        <h3>Matchningshub</h3>
+                        <p>
+                            Rekryterare får en smart, enkel översikt över kandidaterna och kan swipa, kommentera och boka nästa steg.
+                        </p>
+                    </article>
+                    <article class="process-step">
+                        <span>4</span>
+                        <h3>Aktivering &amp; uppföljning</h3>
+                        <p>
+                            Vi sköter uppföljningar, uppdaterar profiler och ger er data som underlag till kundpresentationer.
+                        </p>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section>
+            <div class="container">
+                <div class="metrics" aria-label="Resultat med TandemTalent">
+                    <div class="metric-card">
+                        <h3>3x</h3>
+                        <p>Snabbare tid till shortlist jämfört med traditionella processer.</p>
+                    </div>
+                    <div class="metric-card">
+                        <h3>85%</h3>
+                        <p>Kandidater som bokar ett möte efter första swipen.</p>
+                    </div>
+                    <div class="metric-card">
+                        <h3>92%</h3>
+                        <p>Nöjda kundteam tack vare transparent pipeline och insikter.</p>
+                    </div>
+                    <div class="metric-card">
+                        <h3>24/7</h3>
+                        <p>Kandidatflöde som uppdateras automatiskt varje vecka.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section style="background: #ffffff;">
+            <div class="container">
+                <div class="section-header">
+                    <h2>Kundcase</h2>
+                    <p>
+                        Se hur rekryteringsbyråer använder TandemTalent för att vinna fler uppdrag, skapa bättre kandidatupplevelse och leverera snabbare.
+                    </p>
+                </div>
+                <div class="testimonial-grid">
+                    <article class="testimonial">
+                        <p>
+                            "Med TandemTalent kan våra konsultchefer se exakt vilka kandidater som finns tillgängliga och swipa fram en shortlist på minuter. Vi har halverat vår tid till kundpresentation."
+                        </p>
+                        <strong>Petra Holm, VD på Nordic Logistics Rekrytering</strong>
+                    </article>
+                    <article class="testimonial">
+                        <p>
+                            "Vi får färdiga kandidatkort som känns personliga och ger ett professionellt första intryck. Att matchningsgraden redan är satt gör att vi vågar gå till kund snabbare."
+                        </p>
+                        <strong>Jonas Ek, Team Lead, PeopleFirst</strong>
+                    </article>
+                    <article class="testimonial">
+                        <p>
+                            "Systemet gör gallringen åt oss. Rekryterarna älskar swipe-funktionen, och kandidaterna uppskattar hur snabbt vi återkopplar."
+                        </p>
+                        <strong>Mira Das, Operativ chef, Talentera</strong>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section>
+            <div class="container">
+                <div class="section-header">
+                    <h2>Er branding – vår teknik</h2>
+                    <p>
+                        TandemTalent white-labelas enkelt och integreras i era befintliga system. Koppla på ATS, CRM eller interna dashboards för att hålla koll på kandidater, kundcase och kommunikation.
+                    </p>
+                </div>
+                <div class="feature-grid">
+                    <article class="feature-card">
+                        <div class="feature-icon" aria-hidden="true">🔌</div>
+                        <h3>Integrationer</h3>
+                        <p>
+                            API och färdiga kopplingar till de vanligaste systemen gör implementationen snabb och smidig.
+                        </p>
+                    </article>
+                    <article class="feature-card">
+                        <div class="feature-icon" aria-hidden="true">🎯</div>
+                        <h3>Målgruppsanpassning</h3>
+                        <p>
+                            Segmentera kandidater efter bransch, region och senioritet. Skapa nischade pipelines för varje uppdrag.
+                        </p>
+                    </article>
+                    <article class="feature-card">
+                        <div class="feature-icon" aria-hidden="true">🛡️</div>
+                        <h3>Säkerhet &amp; integritet</h3>
+                        <p>
+                            GDPR-säkrad hantering av kandidatdata, samtyckesflöden och loggning av all aktivitet.
+                        </p>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section>
+            <div class="container">
+                <div class="cta-section">
+                    <h2>Boka en demo och se TandemTalent live</h2>
+                    <p>
+                        Fyll i dina kontaktuppgifter så återkommer vi inom 24 timmar med en skräddarsydd demo. Vi visar hur ni kan lansera er egen swipe-upplevelse för rekrytering.
+                    </p>
+                    <a href="kontakt.html" class="button">Boka demo</a>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <div class="container">
+            <div class="footer-grid">
+                <div>
+                    <strong>TandemTalent</strong>
+                    <p>Rekryteringsplattformen som kombinerar smart matchning med en dejtingapp-känsla.</p>
+                </div>
+                <div>
+                    <strong>Utforska</strong>
+                    <ul>
+                        <li><a href="losning.html">Lösningen</a></li>
+                        <li><a href="process.html">Processen</a></li>
+                        <li><a href="screening.html">Kandidatintag</a></li>
+                        <li><a href="case.html">Kundcase</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <strong>Kontakt</strong>
+                    <ul>
+                        <li><a href="mailto:hej@tandemtalent.se">hej@tandemtalent.se</a></li>
+                        <li><a href="tel:+46101234567">+46 (0)10 123 45 67</a></li>
+                        <li><a href="kontakt.html">Boka demo</a></li>
+                    </ul>
+                </div>
+            </div>
+            <p>&copy; <span id="year"></span> TandemTalent. Skapad för rekryteringsbyråer som vill ligga steget före.</p>
+        </div>
+    </footer>
+
+    <script src="assets/js/app.js" defer></script>
 </body>
 </html>

--- a/kontakt.html
+++ b/kontakt.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Boka demo – TandemTalent</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body data-page="kontakt">
+    <header>
+        <div class="container">
+            <nav>
+                <a href="index.html" class="logo" aria-label="TandemTalent startsida">
+                    <span>TT</span>
+                    TandemTalent
+                </a>
+                <ul>
+                    <li><a href="losning.html">Lösningen</a></li>
+                    <li><a href="process.html">Så funkar det</a></li>
+                    <li><a href="screening.html">Kandidatintag</a></li>
+                    <li><a href="case.html">Kundcase</a></li>
+                    <li><a href="kontakt.html" class="is-active">Boka demo</a></li>
+                </ul>
+                <a href="kontakt.html" class="button">Boka demo</a>
+            </nav>
+            <div class="page-hero">
+                <h1>Se TandemTalent live</h1>
+                <p>
+                    Boka ett förutsättningslöst möte där vi går igenom hur du kan sätta upp egna rekryteringar, screeningfrågor och kundflöden.
+                </p>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section>
+            <div class="container">
+                <div class="contact-grid">
+                    <div class="contact-copy">
+                        <h2>Boka en demo och få en skräddarsydd plan</h2>
+                        <p>
+                            Fyll i dina uppgifter så återkommer vi inom 24 timmar. Vi förbereder ett case baserat på era vanligaste roller och visar hur screening, swipe och kundrapportering ser ut.
+                        </p>
+                        <ul class="contact-list">
+                            <li>45 min genomgång av plattformen</li>
+                            <li>Diskussion om era kravprofiler och frågor</li>
+                            <li>Roadmap för onboarding och implementation</li>
+                        </ul>
+                        <p><strong>Direktkontakt:</strong> <a href="mailto:hej@tandemtalent.se">hej@tandemtalent.se</a> · <a href="tel:+46101234567">+46 (0)10 123 45 67</a></p>
+                    </div>
+                    <form class="intake-form contact-form" id="contactForm">
+                        <div class="form-group">
+                            <label for="contactName">Ditt namn</label>
+                            <input type="text" id="contactName" name="name" autocomplete="name" required />
+                        </div>
+                        <div class="form-group">
+                            <label for="contactCompany">Företag</label>
+                            <input type="text" id="contactCompany" name="company" required />
+                        </div>
+                        <div class="form-group">
+                            <label for="contactEmail">E-post</label>
+                            <input type="email" id="contactEmail" name="email" autocomplete="email" required />
+                        </div>
+                        <div class="form-group">
+                            <label for="contactPhone">Telefon</label>
+                            <input type="tel" id="contactPhone" name="phone" autocomplete="tel" />
+                        </div>
+                        <div class="form-group">
+                            <label for="contactRoles">Vilka roller rekryterar ni främst?</label>
+                            <input type="text" id="contactRoles" name="roles" />
+                        </div>
+                        <div class="form-group">
+                            <label for="contactMessage">Vad vill du att vi fokuserar på?</label>
+                            <textarea id="contactMessage" name="message" rows="4"></textarea>
+                        </div>
+                        <div class="intake-actions">
+                            <button type="submit" class="button">Skicka förfrågan</button>
+                            <p class="form-feedback" id="contactFeedback" role="status" aria-live="polite"></p>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <div class="container">
+            <div class="footer-grid">
+                <div>
+                    <strong>TandemTalent</strong>
+                    <p>Rekryteringsplattformen som kombinerar smart matchning med en dejtingapp-känsla.</p>
+                </div>
+                <div>
+                    <strong>Utforska</strong>
+                    <ul>
+                        <li><a href="losning.html">Lösningen</a></li>
+                        <li><a href="process.html">Processen</a></li>
+                        <li><a href="screening.html">Kandidatintag</a></li>
+                        <li><a href="case.html">Kundcase</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <strong>Kontakt</strong>
+                    <ul>
+                        <li><a href="mailto:hej@tandemtalent.se">hej@tandemtalent.se</a></li>
+                        <li><a href="tel:+46101234567">+46 (0)10 123 45 67</a></li>
+                        <li><a href="kontakt.html" class="is-active">Boka demo</a></li>
+                    </ul>
+                </div>
+            </div>
+            <p>&copy; <span id="year"></span> TandemTalent. Skapad för rekryteringsbyråer som vill ligga steget före.</p>
+        </div>
+    </footer>
+
+    <script src="assets/js/app.js" defer></script>
+</body>
+</html>

--- a/losning.html
+++ b/losning.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lösningen – TandemTalent</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body data-page="losning">
+    <header>
+        <div class="container">
+            <nav>
+                <a href="index.html" class="logo" aria-label="TandemTalent startsida">
+                    <span>TT</span>
+                    TandemTalent
+                </a>
+                <ul>
+                    <li><a href="losning.html" class="is-active">Lösningen</a></li>
+                    <li><a href="process.html">Så funkar det</a></li>
+                    <li><a href="screening.html">Kandidatintag</a></li>
+                    <li><a href="case.html">Kundcase</a></li>
+                    <li><a href="kontakt.html">Boka demo</a></li>
+                </ul>
+                <a href="kontakt.html" class="button">Boka demo</a>
+            </nav>
+            <div class="page-hero">
+                <h1>Allt du behöver för att leverera matchade kandidater i rekordfart</h1>
+                <p>
+                    TandemTalent kombinerar sourcing, screening och presentation i en plattform som känns lika enkel som en dejtingapp.
+                    Våra white-labelmoduler låter dig sätta din egen profil på hela upplevelsen.
+                </p>
+                <div class="hero-actions">
+                    <a href="screening.html" class="button">Utforska kandidatintaget</a>
+                    <a href="kontakt.html" class="button button-secondary">Boka genomgång</a>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section>
+            <div class="container">
+                <div class="section-header">
+                    <h2>En kandidatpipeline som alltid är redo att swipas</h2>
+                    <p>
+                        Vi bygger upp ett uppdaterat kandidatnätverk inom era prioriterade roller. Varje kandidat matchas mot
+                        era kravprofiler och presenteras i ett enkelt kortformat där rekryterarna snabbt ser drivkrafter,
+                        kompetens och nästa steg.
+                    </p>
+                </div>
+                <div class="feature-grid">
+                    <article class="feature-card">
+                        <div class="feature-icon" aria-hidden="true">🤝</div>
+                        <h3>Smart matchning</h3>
+                        <p>
+                            Våra algoritmer väger samman erfarenhet, kompetens, personlig motivation och era must-haves för
+                            att bara visa relevanta kandidater.
+                        </p>
+                    </article>
+                    <article class="feature-card">
+                        <div class="feature-icon" aria-hidden="true">🗂️</div>
+                        <h3>Kandidatkort som säljer in</h3>
+                        <p>
+                            Genomtänkta profiler med foto, personligt statement, styrkor och rekommenderade nästa steg gör det
+                            enkelt att gå från intresse till kontakt.
+                        </p>
+                    </article>
+                    <article class="feature-card">
+                        <div class="feature-icon" aria-hidden="true">⚙️</div>
+                        <h3>Automatisk förkvalificering</h3>
+                        <p>
+                            Kandidater som inte matchar er kravprofil sorteras bort redan innan de visas, vilket sparar tid och
+                            skapar bättre kandidat- och rekryterarupplevelse.
+                        </p>
+                    </article>
+                    <article class="feature-card">
+                        <div class="feature-icon" aria-hidden="true">📊</div>
+                        <h3>Insikter i realtid</h3>
+                        <p>
+                            Följ pipelines, svarsfrekvens och tid till anställning i realtid. Dela insikter med kunder och få ett
+                            faktabaserat beslutsstöd.
+                        </p>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section style="background: #ffffff;">
+            <div class="container">
+                <div class="section-header">
+                    <h2>Er branding – vår teknik</h2>
+                    <p>
+                        TandemTalent white-labelas enkelt och integreras i era befintliga system. Koppla på ATS, CRM eller interna dashboards för att hålla koll på kandidater, kundcase och kommunikation.
+                    </p>
+                </div>
+                <div class="feature-grid">
+                    <article class="feature-card">
+                        <div class="feature-icon" aria-hidden="true">🔌</div>
+                        <h3>Integrationer</h3>
+                        <p>
+                            API och färdiga kopplingar till de vanligaste systemen gör implementationen snabb och smidig.
+                        </p>
+                    </article>
+                    <article class="feature-card">
+                        <div class="feature-icon" aria-hidden="true">🎯</div>
+                        <h3>Målgruppsanpassning</h3>
+                        <p>
+                            Segmentera kandidater efter bransch, region och senioritet. Skapa nischade pipelines för varje uppdrag.
+                        </p>
+                    </article>
+                    <article class="feature-card">
+                        <div class="feature-icon" aria-hidden="true">🛡️</div>
+                        <h3>Säkerhet &amp; integritet</h3>
+                        <p>
+                            GDPR-säkrad hantering av kandidatdata, samtyckesflöden och loggning av all aktivitet.
+                        </p>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section>
+            <div class="container">
+                <div class="metrics" aria-label="Resultat med TandemTalent">
+                    <div class="metric-card">
+                        <h3>3x</h3>
+                        <p>Snabbare tid till shortlist jämfört med traditionella processer.</p>
+                    </div>
+                    <div class="metric-card">
+                        <h3>85%</h3>
+                        <p>Kandidater som bokar ett möte efter första swipen.</p>
+                    </div>
+                    <div class="metric-card">
+                        <h3>92%</h3>
+                        <p>Nöjda kundteam tack vare transparent pipeline och insikter.</p>
+                    </div>
+                    <div class="metric-card">
+                        <h3>24/7</h3>
+                        <p>Kandidatflöde som uppdateras automatiskt varje vecka.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <div class="container">
+            <div class="footer-grid">
+                <div>
+                    <strong>TandemTalent</strong>
+                    <p>Rekryteringsplattformen som kombinerar smart matchning med en dejtingapp-känsla.</p>
+                </div>
+                <div>
+                    <strong>Utforska</strong>
+                    <ul>
+                        <li><a href="losning.html" class="is-active">Lösningen</a></li>
+                        <li><a href="process.html">Processen</a></li>
+                        <li><a href="screening.html">Kandidatintag</a></li>
+                        <li><a href="case.html">Kundcase</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <strong>Kontakt</strong>
+                    <ul>
+                        <li><a href="mailto:hej@tandemtalent.se">hej@tandemtalent.se</a></li>
+                        <li><a href="tel:+46101234567">+46 (0)10 123 45 67</a></li>
+                        <li><a href="kontakt.html">Boka demo</a></li>
+                    </ul>
+                </div>
+            </div>
+            <p>&copy; <span id="year"></span> TandemTalent. Skapad för rekryteringsbyråer som vill ligga steget före.</p>
+        </div>
+    </footer>
+
+    <script src="assets/js/app.js" defer></script>
+</body>
+</html>

--- a/process.html
+++ b/process.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Processen – TandemTalent</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body data-page="process">
+    <header>
+        <div class="container">
+            <nav>
+                <a href="index.html" class="logo" aria-label="TandemTalent startsida">
+                    <span>TT</span>
+                    TandemTalent
+                </a>
+                <ul>
+                    <li><a href="losning.html">Lösningen</a></li>
+                    <li><a href="process.html" class="is-active">Så funkar det</a></li>
+                    <li><a href="screening.html">Kandidatintag</a></li>
+                    <li><a href="case.html">Kundcase</a></li>
+                    <li><a href="kontakt.html">Boka demo</a></li>
+                </ul>
+                <a href="kontakt.html" class="button">Boka demo</a>
+            </nav>
+            <div class="page-hero">
+                <h1>Från behov till signerad kandidat – steg för steg</h1>
+                <p>
+                    Vårt team hjälper dig att definiera kravprofil, sätta upp kampanjer och driva kandidater genom pipeline.
+                    Du får full transparens och kan swipa igenom relevanta profiler så snart de klarat screeningen.
+                </p>
+                <div class="hero-actions">
+                    <a href="screening.html" class="button">Se kandidaten i flödet</a>
+                    <a href="kontakt.html" class="button button-secondary">Prata process</a>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section>
+            <div class="container">
+                <div class="section-header">
+                    <h2>Så tar vi er från behov till signerad kandidat</h2>
+                    <p>
+                        Med TandemTalent blir rekrytering en upplevelse med tempo. Vi driver flödet så att ni kan fokusera på kund- och kandidatdialogen.
+                    </p>
+                </div>
+                <div class="process-grid">
+                    <article class="process-step">
+                        <span>1</span>
+                        <h3>Profilworkshop</h3>
+                        <p>
+                            Tillsammans ringar vi in vilka roller, kompetenser och mjuka värden som ska prioriteras i er pipeline.
+                        </p>
+                    </article>
+                    <article class="process-step">
+                        <span>2</span>
+                        <h3>Talent sourcing &amp; pre-screening</h3>
+                        <p>
+                            Vi skapar en skräddarsydd kampanj, samlar in kandidatdata och gör första urvalet baserat på era kriterier.
+                        </p>
+                    </article>
+                    <article class="process-step">
+                        <span>3</span>
+                        <h3>Matchningshub</h3>
+                        <p>
+                            Rekryterare får en smart, enkel översikt över kandidaterna och kan swipa, kommentera och boka nästa steg.
+                        </p>
+                    </article>
+                    <article class="process-step">
+                        <span>4</span>
+                        <h3>Aktivering &amp; uppföljning</h3>
+                        <p>
+                            Vi sköter uppföljningar, uppdaterar profiler och ger er data som underlag till kundpresentationer.
+                        </p>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section style="background: #ffffff;">
+            <div class="container">
+                <div class="section-header">
+                    <h2>Skalbarhet utan extra administration</h2>
+                    <p>
+                        Automatiserade påminnelser, integrerade kalendrar och rapporter i realtid gör att du kan lägga tiden på kandidater och kunder – inte excelark.
+                    </p>
+                </div>
+                <div class="feature-grid">
+                    <article class="feature-card">
+                        <div class="feature-icon" aria-hidden="true">⏱️</div>
+                        <h3>Färdiga flöden</h3>
+                        <p>Öppna, pausa och duplicera rekryteringar med ett klick. All data följer med.</p>
+                    </article>
+                    <article class="feature-card">
+                        <div class="feature-icon" aria-hidden="true">🧭</div>
+                        <h3>Tydliga nästa steg</h3>
+                        <p>Checklistor och automatiska påminnelser säkerställer att kandidater aldrig faller mellan stolarna.</p>
+                    </article>
+                    <article class="feature-card">
+                        <div class="feature-icon" aria-hidden="true">📈</div>
+                        <h3>Rapporter i realtid</h3>
+                        <p>Följ svarsfrekvens, tid till shortlist och pipeline-hälsa med dashboards som kan delas med kund.</p>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <div class="container">
+            <div class="footer-grid">
+                <div>
+                    <strong>TandemTalent</strong>
+                    <p>Rekryteringsplattformen som kombinerar smart matchning med en dejtingapp-känsla.</p>
+                </div>
+                <div>
+                    <strong>Utforska</strong>
+                    <ul>
+                        <li><a href="losning.html">Lösningen</a></li>
+                        <li><a href="process.html" class="is-active">Processen</a></li>
+                        <li><a href="screening.html">Kandidatintag</a></li>
+                        <li><a href="case.html">Kundcase</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <strong>Kontakt</strong>
+                    <ul>
+                        <li><a href="mailto:hej@tandemtalent.se">hej@tandemtalent.se</a></li>
+                        <li><a href="tel:+46101234567">+46 (0)10 123 45 67</a></li>
+                        <li><a href="kontakt.html">Boka demo</a></li>
+                    </ul>
+                </div>
+            </div>
+            <p>&copy; <span id="year"></span> TandemTalent. Skapad för rekryteringsbyråer som vill ligga steget före.</p>
+        </div>
+    </footer>
+
+    <script src="assets/js/app.js" defer></script>
+</body>
+</html>

--- a/screening.html
+++ b/screening.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kandidatintag – TandemTalent</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body data-page="screening">
+    <header>
+        <div class="container">
+            <nav>
+                <a href="index.html" class="logo" aria-label="TandemTalent startsida">
+                    <span>TT</span>
+                    TandemTalent
+                </a>
+                <ul>
+                    <li><a href="losning.html">Lösningen</a></li>
+                    <li><a href="process.html">Så funkar det</a></li>
+                    <li><a href="screening.html" class="is-active">Kandidatintag</a></li>
+                    <li><a href="case.html">Kundcase</a></li>
+                    <li><a href="kontakt.html">Boka demo</a></li>
+                </ul>
+                <a href="kontakt.html" class="button">Boka demo</a>
+            </nav>
+            <div class="page-hero">
+                <h1>Bygg rekryteringar och låt kandidater kvalificera sig själva</h1>
+                <p>
+                    Skapa uppdrag, ställ in screeningfrågor och låt TandemTalent gallra kandidater automatiskt. Rekryterare får ett swipe-flöde med redan matchade profiler.
+                </p>
+                <div class="hero-actions">
+                    <a href="#workspace" class="button">Starta screening</a>
+                    <a href="kontakt.html" class="button button-secondary">Boka demo</a>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section id="workspace" class="screening-workspace">
+            <div class="container">
+                <div class="workspace-grid">
+                    <div class="workspace-column">
+                        <article class="card recruitment-card">
+                            <header class="card-header">
+                                <h2>Skapa ny rekrytering</h2>
+                                <p class="muted">Definiera roll, krav och screeningfrågor. Rekryteringen sparas lokalt.</p>
+                            </header>
+                            <form id="recruitmentForm" class="intake-form" novalidate>
+                                <div class="form-grid">
+                                    <div class="form-group">
+                                        <label for="recruitmentName">Intern benämning</label>
+                                        <input type="text" id="recruitmentName" name="name" placeholder="Ex. Lagerteam Q1" required />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="recruitmentRole">Roll / titel</label>
+                                        <input type="text" id="recruitmentRole" name="role" placeholder="Ex. Lagermedarbetare" required />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="recruitmentLocation">Ort</label>
+                                        <input type="text" id="recruitmentLocation" name="location" placeholder="Göteborg" required />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="recruitmentThreshold">Antal ja-svar som krävs</label>
+                                        <input type="number" id="recruitmentThreshold" name="threshold" min="1" value="4" />
+                                        <small class="input-help">Justera efter hur många frågor du lägger till.</small>
+                                    </div>
+                                </div>
+                                <div class="question-builder">
+                                    <div class="question-builder-header">
+                                        <h3>Screeningfrågor</h3>
+                                        <button type="button" id="addQuestionButton" class="text-button">+ Lägg till fråga</button>
+                                    </div>
+                                    <p class="muted">Max 6 frågor. Minst 3 behövs för att skapa en rekrytering.</p>
+                                    <div id="questionList" class="question-list"></div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="recruitmentRequirements">Måstekrav</label>
+                                    <textarea id="recruitmentRequirements" name="requirements" rows="4" placeholder="Skriv ett krav per rad"></textarea>
+                                </div>
+                                <div class="intake-actions">
+                                    <button type="submit" class="button">Skapa rekrytering</button>
+                                    <p class="form-feedback" id="recruitmentFeedback" role="status" aria-live="polite"></p>
+                                </div>
+                            </form>
+                        </article>
+
+                        <article class="card recruitment-card">
+                            <header class="card-header">
+                                <h2>Aktiva rekryteringar</h2>
+                                <p class="muted">Välj en rekrytering för att registrera kandidater och se matchade profiler.</p>
+                            </header>
+                            <div id="recruitmentList" class="recruitment-list" aria-live="polite"></div>
+                        </article>
+                    </div>
+
+                    <div class="workspace-column">
+                        <article class="card active-recruitment">
+                            <header class="card-header">
+                                <h2 id="activeRecruitmentTitle">Ingen rekrytering vald</h2>
+                                <p id="activeRecruitmentMeta" class="muted">Skapa eller välj en rekrytering för att se detaljer.</p>
+                            </header>
+                            <div class="active-recruitment-body" id="activeRecruitmentBody">
+                                <div class="active-summary">
+                                    <div>
+                                        <h3>Roll &amp; plats</h3>
+                                        <p id="activeRecruitmentRole" class="muted">–</p>
+                                    </div>
+                                    <div>
+                                        <h3>Tröskel</h3>
+                                        <p id="activeThreshold" class="muted">–</p>
+                                    </div>
+                                </div>
+                                <div class="active-stacks">
+                                    <div>
+                                        <h3>Måstekrav</h3>
+                                        <ul id="activeRequirements" class="requirements-list"></ul>
+                                    </div>
+                                    <div>
+                                        <h3>Screeningfrågor</h3>
+                                        <ol id="activeQuestionList" class="question-preview"></ol>
+                                    </div>
+                                </div>
+                            </div>
+                        </article>
+
+                        <article class="card">
+                            <header class="card-header">
+                                <h2>Registrera kandidat</h2>
+                                <p id="candidateFormHelper" class="muted">Välj en rekrytering för att aktivera formuläret.</p>
+                            </header>
+                            <form class="intake-form" id="candidateForm" novalidate>
+                                <div class="form-grid">
+                                    <div class="form-group">
+                                        <label for="candidateName">Kandidatnamn</label>
+                                        <input type="text" id="candidateName" name="name" autocomplete="name" required />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="candidateExperience">År av erfarenhet</label>
+                                        <input type="number" id="candidateExperience" name="experience" min="0" max="50" step="1" required />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="candidateLocation">Ort</label>
+                                        <input type="text" id="candidateLocation" name="location" autocomplete="address-level2" required />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="candidatePitch">Kort presentation</label>
+                                        <textarea id="candidatePitch" name="pitch" rows="3" placeholder="Vad driver kandidaten?" required></textarea>
+                                    </div>
+                                </div>
+                                <div id="candidateQuestionFields" class="dynamic-questions"></div>
+                                <div class="intake-actions">
+                                    <button type="submit" class="button">Utvärdera kandidat</button>
+                                    <p class="form-feedback" id="candidateFeedback" role="status" aria-live="polite"></p>
+                                </div>
+                            </form>
+                        </article>
+
+                        <article class="card review-card">
+                            <header class="review-header">
+                                <div>
+                                    <h2>Rekryterarvy</h2>
+                                    <p class="muted">Kandidater som passerat tröskeln visas här en i taget.</p>
+                                </div>
+                                <div class="review-stats">
+                                    <span class="stat-badge">I kö: <strong id="pipelineCount">0</strong></span>
+                                    <span class="stat-badge">Accepterade: <strong id="acceptedCount">0</strong></span>
+                                </div>
+                            </header>
+                            <p class="form-feedback" id="reviewFeedback" role="status" aria-live="polite"></p>
+                            <div id="pipelineEmpty" class="empty-state">Inga kvalificerade kandidater ännu. När en kandidat uppfyller kraven dyker den upp här.</div>
+                            <div id="candidateReviewContent" class="review-content" aria-live="polite"></div>
+                            <div class="review-actions">
+                                <button type="button" id="rejectCandidateBtn" class="swipe-button no" disabled>Passa</button>
+                                <button type="button" id="acceptCandidateBtn" class="swipe-button yes" disabled>Tacka ja</button>
+                            </div>
+                        </article>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <div class="container">
+            <div class="footer-grid">
+                <div>
+                    <strong>TandemTalent</strong>
+                    <p>Rekryteringsplattformen som kombinerar smart matchning med en dejtingapp-känsla.</p>
+                </div>
+                <div>
+                    <strong>Utforska</strong>
+                    <ul>
+                        <li><a href="losning.html">Lösningen</a></li>
+                        <li><a href="process.html">Processen</a></li>
+                        <li><a href="screening.html" class="is-active">Kandidatintag</a></li>
+                        <li><a href="case.html">Kundcase</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <strong>Kontakt</strong>
+                    <ul>
+                        <li><a href="mailto:hej@tandemtalent.se">hej@tandemtalent.se</a></li>
+                        <li><a href="tel:+46101234567">+46 (0)10 123 45 67</a></li>
+                        <li><a href="kontakt.html">Boka demo</a></li>
+                    </ul>
+                </div>
+            </div>
+            <p>&copy; <span id="year"></span> TandemTalent. Skapad för rekryteringsbyråer som vill ligga steget före.</p>
+        </div>
+    </footer>
+
+    <script src="assets/js/app.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- convert the landing experience to link to dedicated solution, process, case, and contact pages and add those standalone views
- add a configurable recruitment workspace with dynamic screening questions, candidate intake, and swipe-style review for qualified matches
- refresh styling and contact interactions to support the new multi-page workflow

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e53c0b81788325924af9eef2834d51